### PR TITLE
Add desktop icon activation and custom context menu

### DIFF
--- a/app.js
+++ b/app.js
@@ -18,7 +18,8 @@
     },
     desktop: {
       icons: {},
-      wallpaperCustom: ''
+      wallpaperCustom: '',
+      activeIcon: null
     },
     windows: {},
     notes: {
@@ -698,6 +699,10 @@
   const launcherResults = document.getElementById('launcher-results');
   let launcherSelection = 0;
   const activeAppDisplay = document.getElementById('active-app-display');
+  let contextMenu;
+  let contextMenuList;
+  let statusTimeout = null;
+  let lastStatusFallback = 'Ready';
 
   function loadState() {
     try {
@@ -734,6 +739,25 @@
   function saveStateDebounced() {
     clearTimeout(saveTimeout);
     saveTimeout = setTimeout(saveState, 400);
+  }
+
+  function setActiveAppLabel(label) {
+    lastStatusFallback = label || 'Ready';
+    clearTimeout(statusTimeout);
+    statusTimeout = null;
+    activeAppDisplay.textContent = lastStatusFallback;
+  }
+
+  function announce(message, duration = 1800) {
+    if (!message) return;
+    clearTimeout(statusTimeout);
+    const fallback = lastStatusFallback;
+    activeAppDisplay.textContent = message;
+    statusTimeout = setTimeout(() => {
+      if (activeAppDisplay.textContent === message) {
+        activeAppDisplay.textContent = fallback;
+      }
+    }, duration);
   }
 
   function applyTheme() {
@@ -912,13 +936,23 @@
       const coords = state.desktop.icons[app.id] || { x: 40, y: 40 };
       icon.style.left = `${coords.x}px`;
       icon.style.top = `${coords.y}px`;
+      icon.addEventListener('click', () => {
+        setActiveIcon(app.id);
+      });
       icon.addEventListener('dblclick', () => {
         openWindow(app.id);
         soundEngine.play(520, 0.12);
       });
+      icon.addEventListener('contextmenu', (event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        setActiveIcon(app.id);
+        showContextMenu(getIconContextMenuItems(app.id), event.clientX, event.clientY);
+      });
       enableIconDrag(icon);
       iconLayer.appendChild(icon);
     });
+    updateIconSelection();
   }
 
   function enableIconDrag(icon) {
@@ -929,6 +963,7 @@
 
     icon.addEventListener('mousedown', (event) => {
       if (event.button !== 0) return;
+      setActiveIcon(icon.dataset.app);
       startX = event.clientX;
       startY = event.clientY;
       const coords = state.desktop.icons[icon.dataset.app];
@@ -958,11 +993,126 @@
       document.removeEventListener('mousemove', onMove);
       document.removeEventListener('mouseup', onUp);
       saveState();
+      updateIconSelection();
     }
   }
 
   function clamp(value, min, max) {
     return Math.min(Math.max(value, min), max);
+  }
+
+  function setActiveIcon(appId) {
+    const next = appId || null;
+    if (state.desktop.activeIcon === next) return;
+    state.desktop.activeIcon = next;
+    updateIconSelection();
+    saveStateDebounced();
+  }
+
+  function clearActiveIcon() {
+    if (!state.desktop.activeIcon) return;
+    state.desktop.activeIcon = null;
+    updateIconSelection();
+    saveStateDebounced();
+  }
+
+  function updateIconSelection() {
+    const icons = iconLayer.querySelectorAll('.desktop-icon');
+    icons.forEach((el) => {
+      el.classList.toggle('active', el.dataset.app === state.desktop.activeIcon);
+    });
+  }
+
+  function getIconContextMenuItems(appId) {
+    const app = apps[appId];
+    if (!app) return [];
+    return [
+      { label: `Open ${app.name}`, action: () => openWindow(appId) },
+      { label: 'Open Settings', action: () => openWindow('settings') },
+      { label: 'Show Info', action: () => announce(`${app.name} • ${app.glyph}`) }
+    ];
+  }
+
+  function getDesktopContextMenuItems() {
+    const ids = ['new-note', 'new-task', 'toggle-theme', 'open-settings'];
+    return quickActions
+      .filter((action) => ids.includes(action.id))
+      .map((action) => ({ label: action.label, action: action.handler }));
+  }
+
+  function getGlobalContextMenuItems() {
+    return [
+      {
+        label: 'Toggle Theme',
+        action: () => {
+          state.settings.theme = state.settings.theme === 'light' ? 'dark' : 'light';
+          applyTheme();
+          saveState();
+        }
+      },
+      { label: 'Open Settings', action: () => openWindow('settings') },
+      {
+        label: 'Show Desktop',
+        action: () => {
+          Array.from(windowLayer.querySelectorAll('.window')).forEach((win) => {
+            win.dataset.minimized = 'true';
+            win.style.display = 'none';
+            const id = win.dataset.app;
+            if (state.windows[id]) {
+              state.windows[id].minimized = true;
+            }
+          });
+          saveStateDebounced();
+          setActiveAppLabel('Ready');
+        }
+      }
+    ];
+  }
+
+  function initContextMenu() {
+    if (contextMenu) return;
+    contextMenu = document.createElement('div');
+    contextMenu.id = 'context-menu';
+    contextMenu.className = 'context-menu hidden';
+    contextMenuList = document.createElement('ul');
+    contextMenu.appendChild(contextMenuList);
+    document.body.appendChild(contextMenu);
+  }
+
+  function showContextMenu(items, x, y) {
+    if (!items || !items.length) {
+      hideContextMenu();
+      return;
+    }
+    if (!contextMenu || !contextMenuList) {
+      initContextMenu();
+    }
+    contextMenuList.innerHTML = '';
+    items.forEach((item) => {
+      const li = document.createElement('li');
+      const button = document.createElement('button');
+      button.type = 'button';
+      button.textContent = item.label;
+      button.addEventListener('click', () => {
+        hideContextMenu();
+        item.action?.();
+      });
+      li.appendChild(button);
+      contextMenuList.appendChild(li);
+    });
+    contextMenu.classList.remove('hidden');
+    contextMenu.style.left = `${x}px`;
+    contextMenu.style.top = `${y}px`;
+    const { offsetWidth, offsetHeight } = contextMenu;
+    const maxX = window.innerWidth - offsetWidth - 8;
+    const maxY = window.innerHeight - offsetHeight - 8;
+    contextMenu.style.left = `${Math.max(8, Math.min(x, maxX))}px`;
+    contextMenu.style.top = `${Math.max(8, Math.min(y, maxY))}px`;
+  }
+
+  function hideContextMenu() {
+    if (!contextMenu) return;
+    contextMenu.classList.add('hidden');
   }
 
   function openWindow(appId, afterRender) {
@@ -1051,7 +1201,7 @@
       windowEl.remove();
       delete state.windows[appId];
       saveState();
-      activeAppDisplay.textContent = 'Ready';
+      setActiveAppLabel('Ready');
     });
 
     minimizeBtn.addEventListener('click', () => {
@@ -1117,7 +1267,7 @@
     document.querySelectorAll('.window').forEach((win) => win.classList.remove('window-focused'));
     windowEl.classList.add('window-focused');
     const app = apps[windowEl.dataset.app];
-    activeAppDisplay.textContent = app ? app.name : 'Ready';
+    setActiveAppLabel(app ? app.name : 'Ready');
   }
 
   function restoreWindows() {
@@ -1281,6 +1431,7 @@
     window.addEventListener('resize', () => {
       layoutIcons();
       renderIcons();
+      hideContextMenu();
     });
 
     windowLayer.addEventListener('click', (event) => {
@@ -1289,6 +1440,38 @@
       event.preventDefault();
       const appId = link.dataset.open;
       openWindow(appId);
+    });
+
+    iconLayer.addEventListener('mousedown', (event) => {
+      if (event.button !== 0) return;
+      if (!event.target.closest('.desktop-icon')) {
+        clearActiveIcon();
+      }
+    });
+
+    document.addEventListener('click', (event) => {
+      if (!event.target.closest('#context-menu')) {
+        hideContextMenu();
+      }
+    });
+
+    document.addEventListener('scroll', hideContextMenu, true);
+    window.addEventListener('blur', hideContextMenu);
+
+    document.addEventListener('keydown', (event) => {
+      if (event.key === 'Escape') hideContextMenu();
+    });
+
+    document.addEventListener('contextmenu', (event) => {
+      const icon = event.target.closest('.desktop-icon');
+      if (icon) return;
+      event.preventDefault();
+      if (iconLayer.contains(event.target)) {
+        clearActiveIcon();
+        showContextMenu(getDesktopContextMenuItems(), event.clientX, event.clientY);
+      } else {
+        showContextMenu(getGlobalContextMenuItems(), event.clientX, event.clientY);
+      }
     });
   }
 
@@ -1311,11 +1494,13 @@
     layoutIcons();
     renderIcons();
     buildDock();
+    initContextMenu();
     restoreBrowser();
     restoreWindows();
     initTopBar();
     attachGlobalEvents();
     setupLauncher();
+    setActiveAppLabel('Ready');
   }
 
   document.addEventListener('DOMContentLoaded', bootstrap);

--- a/styles.css
+++ b/styles.css
@@ -160,15 +160,69 @@ button {
   box-shadow: 0 14px 40px rgba(20, 16, 32, 0.2);
 }
 
+.desktop-icon.active {
+  outline: 2px solid var(--accent);
+  outline-offset: -6px;
+  background: rgba(255, 255, 255, 0.4);
+  box-shadow: 0 18px 48px rgba(127, 90, 240, 0.25);
+}
+
 .desktop-icon .glyph {
   font-size: 32px;
+}
+
+.context-menu {
+  position: fixed;
+  min-width: 200px;
+  padding: 6px 0;
+  border-radius: 14px;
+  background: var(--window-bg);
+  color: var(--fg);
+  border: 1px solid rgba(255, 255, 255, 0.4);
+  backdrop-filter: blur(12px);
+  box-shadow: 0 22px 55px var(--shadow);
+  z-index: 2000;
+  animation: fade 0.18s ease;
+}
+
+.context-menu ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.context-menu li + li {
+  border-top: 1px solid rgba(255, 255, 255, 0.16);
+}
+
+.context-menu button {
+  width: 100%;
+  padding: 10px 18px;
+  border: none;
+  background: transparent;
+  font: inherit;
+  color: inherit;
+  text-align: left;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.context-menu button:hover,
+.context-menu button:focus-visible {
+  background: var(--accent-soft);
+  color: var(--accent);
+  outline: none;
+}
+
+.context-menu button:active {
+  background: rgba(127, 90, 240, 0.25);
 }
 
 #window-layer {
   padding: 24px;
 }
 
-.window {
+.window { 
   position: absolute;
   background: var(--window-bg);
   border-radius: 18px;


### PR DESCRIPTION
## Summary
- track the active desktop icon in state so icons highlight on selection and stay active across sessions
- wire desktop icons for single-click selection, right-click context menu access, and status messaging helpers for the menu actions
- add a global custom context menu with themed styling and OS-specific options, suppressing the browser default menu everywhere

## Testing
- no automated tests were run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68cdb1c6ce58832496c41c82dabb5095