### PR TITLE
Fix desktop icon interactions and window placement

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -160,12 +160,67 @@ button {
   box-shadow: 0 14px 40px rgba(20, 16, 32, 0.2);
 }
 
+.desktop-icon.active {
+  outline: 2px solid var(--accent);
+  outline-offset: -6px;
+  background: rgba(255, 255, 255, 0.4);
+  box-shadow: 0 18px 48px rgba(127, 90, 240, 0.25);
+}
+
 .desktop-icon .glyph {
   font-size: 32px;
 }
 
+.context-menu {
+  position: fixed;
+  min-width: 200px;
+  padding: 6px 0;
+  border-radius: 14px;
+  background: var(--window-bg);
+  color: var(--fg);
+  border: 1px solid rgba(255, 255, 255, 0.4);
+  backdrop-filter: blur(12px);
+  box-shadow: 0 22px 55px var(--shadow);
+  z-index: 2000;
+  animation: fade 0.18s ease;
+}
+
+.context-menu ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.context-menu li + li {
+  border-top: 1px solid rgba(255, 255, 255, 0.16);
+}
+
+.context-menu button {
+  width: 100%;
+  padding: 10px 18px;
+  border: none;
+  background: transparent;
+  font: inherit;
+  color: inherit;
+  text-align: left;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.context-menu button:hover,
+.context-menu button:focus-visible {
+  background: var(--accent-soft);
+  color: var(--accent);
+  outline: none;
+}
+
+.context-menu button:active {
+  background: rgba(127, 90, 240, 0.25);
+}
+
 #window-layer {
   padding: 24px;
+  pointer-events: none;
 }
 
 .window {
@@ -180,6 +235,7 @@ button {
   min-width: 280px;
   min-height: 220px;
   animation: window-pop 0.32s ease;
+  pointer-events: auto;
 }
 
 @keyframes window-pop {


### PR DESCRIPTION
## Summary
- allow desktop clicks to reach icons by disabling pointer events on the empty window layer while keeping windows interactive
- track the last pointer position and spawn new app windows near the cursor when no saved position exists

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68cdb1c6ce58832496c41c82dabb5095